### PR TITLE
feature/friends-api2

### DIFF
--- a/src/main/java/com/cordingrecipe/groupnewsfeed/friend/controller/FriendController.java
+++ b/src/main/java/com/cordingrecipe/groupnewsfeed/friend/controller/FriendController.java
@@ -4,6 +4,7 @@ import com.cordingrecipe.groupnewsfeed.common.constant.Const;
 import com.cordingrecipe.groupnewsfeed.friend.dto.CreateFriendRequestDto;
 import com.cordingrecipe.groupnewsfeed.friend.dto.CreateFriendResponseDto;
 import com.cordingrecipe.groupnewsfeed.friend.dto.FriendResponseDto;
+import com.cordingrecipe.groupnewsfeed.friend.dto.FriendViewDto;
 import com.cordingrecipe.groupnewsfeed.friend.service.FriendService;
 import com.cordingrecipe.groupnewsfeed.user.dto.UserLoginResponseDto;
 import jakarta.transaction.Transactional;
@@ -22,7 +23,7 @@ public class FriendController {
     private final FriendService friendService;
 
     @PostMapping
-    public ResponseEntity<CreateFriendResponseDto> createFriend(@RequestBody CreateFriendRequestDto requestDto,  @SessionAttribute(Const.LOGIN_USER) UserLoginResponseDto loginUser) {
+    public ResponseEntity<CreateFriendResponseDto> createFriend(@RequestBody CreateFriendRequestDto requestDto,  @SessionAttribute(name = "LOGIN_USER") UserLoginResponseDto loginUser) {
 
         CreateFriendResponseDto createFriendResponseDto =
                 friendService.createFriend(loginUser.getId(), requestDto);
@@ -30,7 +31,7 @@ public class FriendController {
     }
 
     @PatchMapping("requests/{id}/accept")
-    public ResponseEntity<FriendResponseDto> acceptFriendRequest(@PathVariable Long id, @SessionAttribute(Const.LOGIN_USER)UserLoginResponseDto loginUser) {
+    public ResponseEntity<FriendResponseDto> acceptFriendRequest(@PathVariable Long id, @SessionAttribute(name = "LOGIN_USER")UserLoginResponseDto loginUser) {
 
         FriendResponseDto friendResponseDto =
                 friendService.acceptFriendRequest(loginUser.getId(), id);
@@ -41,38 +42,40 @@ public class FriendController {
     //requests/{id} → 친구 요청이라는 자원
     //PATCH → 그 자원의 상태를 변경하겠다는 행위,
     @PatchMapping("requests/{id}/reject")
-    public ResponseEntity<FriendResponseDto> declineFriendRequest(@PathVariable Long id, @SessionAttribute(Const.LOGIN_USER)UserLoginResponseDto loginUser) {
+    public ResponseEntity<FriendResponseDto> declineFriendRequest(@PathVariable Long id, @SessionAttribute(name = "LOGIN_USER")UserLoginResponseDto loginUser) {
 
         FriendResponseDto friendResponseDto = friendService.rejectFriendRequest(loginUser.getId(), id);
         return ResponseEntity.ok(friendResponseDto);
     }
 
     @GetMapping("/received")
-    public ResponseEntity<List<FriendResponseDto>> getFriend(@SessionAttribute(Const.LOGIN_USER)UserLoginResponseDto loginUser) {
+    public ResponseEntity<List<FriendViewDto>> getFriend(@SessionAttribute(name = "LOGIN_USER")UserLoginResponseDto loginUser) {
 
 
-        List<FriendResponseDto> friendList = friendService.getReceivedRequests(loginUser.getId());
+        List<FriendViewDto> friendList = friendService.getReceivedRequests(loginUser.getId());
         return ResponseEntity.ok(friendList);
     }
 
     @GetMapping("/requests/from/received")
-    public ResponseEntity<List<FriendResponseDto>> checkUserSentRequest(@SessionAttribute(Const.LOGIN_USER)UserLoginResponseDto loginUser) {
+    public ResponseEntity<List<FriendResponseDto>> checkUserSentRequest(@SessionAttribute(name = "LOGIN_USER")UserLoginResponseDto loginUser) {
 
         List<FriendResponseDto> friendList = friendService.getPendingFriendRequests(loginUser.getId());
         return ResponseEntity.ok(friendList);
 
     }
 
-    @GetMapping("/relations/between")
-    public ResponseEntity<FriendResponseDto> findFriends(@RequestParam Long fromUserId, @RequestParam Long toUserId,@SessionAttribute(Const.LOGIN_USER)UserLoginResponseDto loginUser) {
+    @GetMapping("/relations")
+    public ResponseEntity<FriendViewDto> getFriendRelation(
+            @RequestParam("friendId") Long friendId,
+            @SessionAttribute(Const.LOGIN_USER) UserLoginResponseDto loginUser) {
 
-        FriendResponseDto friendResponseDto = friendService.findFriends(fromUserId,toUserId,loginUser.getId());
-        return ResponseEntity.ok(friendResponseDto);
+        FriendViewDto response = friendService.findFriend(loginUser.getId(), friendId);
+        return ResponseEntity.ok(response);
     }
 
     @Transactional
     @DeleteMapping("/delete/{id}")
-    public ResponseEntity<FriendResponseDto> deleteFriends(@PathVariable Long id, @SessionAttribute(Const.LOGIN_USER)UserLoginResponseDto loginUser) {
+    public ResponseEntity<FriendResponseDto> deleteFriends(@PathVariable Long id, @SessionAttribute(name = "LOGIN_USER")UserLoginResponseDto loginUser) {
 
         friendService.deleteFriend(loginUser.getId(), id);
         return ResponseEntity.noContent().build(); // 204 No Content

--- a/src/main/java/com/cordingrecipe/groupnewsfeed/friend/controller/FriendController.java
+++ b/src/main/java/com/cordingrecipe/groupnewsfeed/friend/controller/FriendController.java
@@ -39,8 +39,6 @@ public class FriendController {
         return ResponseEntity.ok(friendResponseDto);
     }
 
-    //requests/{id} → 친구 요청이라는 자원
-    //PATCH → 그 자원의 상태를 변경하겠다는 행위,
     @PatchMapping("requests/{id}/reject")
     public ResponseEntity<FriendResponseDto> declineFriendRequest(@PathVariable Long id, @SessionAttribute(name = "LOGIN_USER")UserLoginResponseDto loginUser) {
 
@@ -61,7 +59,6 @@ public class FriendController {
 
         List<FriendResponseDto> friendList = friendService.getPendingFriendRequests(loginUser.getId());
         return ResponseEntity.ok(friendList);
-
     }
 
     @GetMapping("/relations")

--- a/src/main/java/com/cordingrecipe/groupnewsfeed/friend/dto/CreateFriendRequestDto.java
+++ b/src/main/java/com/cordingrecipe/groupnewsfeed/friend/dto/CreateFriendRequestDto.java
@@ -8,12 +8,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(force = true)
 public class CreateFriendRequestDto {
 
-    //requesterId는 session에 처리된 정보로 사용할 것임.
+    private final Long toUserId;
 
-    //친구요청하고 싶은 상대
-    private final Long receiverId;
 
-    public CreateFriendRequestDto(Long receiverId) {
-        this.receiverId = receiverId;
-    }
 }
+

--- a/src/main/java/com/cordingrecipe/groupnewsfeed/friend/dto/CreateFriendResponseDto.java
+++ b/src/main/java/com/cordingrecipe/groupnewsfeed/friend/dto/CreateFriendResponseDto.java
@@ -15,8 +15,6 @@ public class CreateFriendResponseDto {
     private final String status;
     private LocalDateTime createdAt;
 
-
-    //User객체에서 받아와서 User id만 꺼낼
     public CreateFriendResponseDto(Friend friend) {
         this.toUserId = friend.getToUser().getId();
         this.fromUserId = friend.getFromUser().getId();

--- a/src/main/java/com/cordingrecipe/groupnewsfeed/friend/dto/CreateFriendResponseDto.java
+++ b/src/main/java/com/cordingrecipe/groupnewsfeed/friend/dto/CreateFriendResponseDto.java
@@ -10,16 +10,16 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(force = true)
 public class CreateFriendResponseDto {
 
-    private final Long receiverId; //toUserid
-    private final Long senderId;
+    private final Long toUserId;
+    private final Long fromUserId; //toUserid
     private final String status;
     private LocalDateTime createdAt;
 
 
     //User객체에서 받아와서 User id만 꺼낼
     public CreateFriendResponseDto(Friend friend) {
-        this.receiverId = friend.getToUser().getId();
-        this.senderId = friend.getFromUser().getId();
+        this.toUserId = friend.getToUser().getId();
+        this.fromUserId = friend.getFromUser().getId();
         this.status = friend.getStatus().name();
         this.createdAt = friend.getCreatedAt();
     }
@@ -27,3 +27,4 @@ public class CreateFriendResponseDto {
 
 
 }
+//수정완료

--- a/src/main/java/com/cordingrecipe/groupnewsfeed/friend/dto/FriendResponseDto.java
+++ b/src/main/java/com/cordingrecipe/groupnewsfeed/friend/dto/FriendResponseDto.java
@@ -1,7 +1,6 @@
 package com.cordingrecipe.groupnewsfeed.friend.dto;
 
 import com.cordingrecipe.groupnewsfeed.friend.entity.Friend;
-import com.cordingrecipe.groupnewsfeed.user.entity.User;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -18,12 +17,4 @@ public class FriendResponseDto {
         this.toUserId = friend.getToUser().getId();
         this.status = friend.getStatus().name();
     }
-
-    public FriendResponseDto(Friend friend, User me) {
-        this.fromUserId = friend.getFromUser().getId();
-        this.toUserId = friend.getToUser().getId();
-        this.status = friend.getStatus().name();
-    }
-
-
 }

--- a/src/main/java/com/cordingrecipe/groupnewsfeed/friend/dto/FriendResponseDto.java
+++ b/src/main/java/com/cordingrecipe/groupnewsfeed/friend/dto/FriendResponseDto.java
@@ -1,6 +1,7 @@
 package com.cordingrecipe.groupnewsfeed.friend.dto;
 
 import com.cordingrecipe.groupnewsfeed.friend.entity.Friend;
+import com.cordingrecipe.groupnewsfeed.user.entity.User;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -8,13 +9,19 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(force = true)
 public class FriendResponseDto {
 
-    private final Long receiverId; //toUserid
-    private final Long senderId;
+    private final Long toUserId; //toUserid
+    private final Long fromUserId;
     private final String status;
 
     public FriendResponseDto(Friend friend) {
-        this.receiverId = friend.getToUser().getId();
-        this.senderId = friend.getFromUser().getId();
+        this.fromUserId = friend.getFromUser().getId();
+        this.toUserId = friend.getToUser().getId();
+        this.status = friend.getStatus().name();
+    }
+
+    public FriendResponseDto(Friend friend, User me) {
+        this.fromUserId = friend.getFromUser().getId();
+        this.toUserId = friend.getToUser().getId();
         this.status = friend.getStatus().name();
     }
 

--- a/src/main/java/com/cordingrecipe/groupnewsfeed/friend/dto/FriendViewDto.java
+++ b/src/main/java/com/cordingrecipe/groupnewsfeed/friend/dto/FriendViewDto.java
@@ -1,0 +1,19 @@
+package com.cordingrecipe.groupnewsfeed.friend.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(force = true)
+public class FriendViewDto {
+
+    private final Long friendId;
+    private final String friendName;
+
+    public FriendViewDto(Long friendId, String friendName) {
+        this.friendId = friendId;
+        this.friendName = friendName;
+    }
+
+
+}

--- a/src/main/java/com/cordingrecipe/groupnewsfeed/friend/dto/FriendViewDto.java
+++ b/src/main/java/com/cordingrecipe/groupnewsfeed/friend/dto/FriendViewDto.java
@@ -14,6 +14,4 @@ public class FriendViewDto {
         this.friendId = friendId;
         this.friendName = friendName;
     }
-
-
 }

--- a/src/main/java/com/cordingrecipe/groupnewsfeed/friend/entity/Friend.java
+++ b/src/main/java/com/cordingrecipe/groupnewsfeed/friend/entity/Friend.java
@@ -32,11 +32,7 @@ public class Friend extends BaseEntity {
     private FriendRequestStatus status;
 
     public Friend() {
-        
-    }
 
-    public void rejected() {
-        this.status = FriendRequestStatus.REJECTED;
     }
 
     public void pending() {

--- a/src/main/java/com/cordingrecipe/groupnewsfeed/friend/repository/FriendRepository.java
+++ b/src/main/java/com/cordingrecipe/groupnewsfeed/friend/repository/FriendRepository.java
@@ -14,14 +14,13 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
     boolean existsByFromUserAndToUser(User fromUser, User toUser);
 
     Optional<Friend> findByFromUserIdAndToUserIdAndStatus(
-            Long requesterId, Long userId, Friend.FriendRequestStatus status);
+            Long fromUserId, Long toUserId, Friend.FriendRequestStatus status);
 
-    List<Friend> findByFromUserIdAndStatus(
-            Long fromUserId, Friend.FriendRequestStatus status);
+    List<Friend> findByFromUserIdAndStatus(Long fromUserId, Friend.FriendRequestStatus status);
 
     List<Friend> findByToUserIdAndStatus(Long userId, Friend.FriendRequestStatus friendRequestStatus);
 
-    Optional<Friend> findByFromUserIdAndToUserId(Long id, Long id1);
+    Optional<Friend> findByFromUserIdAndToUserId(Long toUserId, Long fromUserId);
 
     boolean existsByFromUserIdAndToUserIdAndStatus(Long fromUserId, Long toUserId, Friend.FriendRequestStatus status);
 
@@ -29,4 +28,5 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
         return existsByFromUserIdAndToUserIdAndStatus(userId, requesterId, status) ||
                 existsByFromUserIdAndToUserIdAndStatus(requesterId, userId, status);
     }
+
 }

--- a/src/main/java/com/cordingrecipe/groupnewsfeed/friend/service/FriendService.java
+++ b/src/main/java/com/cordingrecipe/groupnewsfeed/friend/service/FriendService.java
@@ -6,6 +6,7 @@ import com.cordingrecipe.groupnewsfeed.common.advice.ErrorCode;
 import com.cordingrecipe.groupnewsfeed.friend.dto.CreateFriendRequestDto;
 import com.cordingrecipe.groupnewsfeed.friend.dto.CreateFriendResponseDto;
 import com.cordingrecipe.groupnewsfeed.friend.dto.FriendResponseDto;
+import com.cordingrecipe.groupnewsfeed.friend.dto.FriendViewDto;
 import com.cordingrecipe.groupnewsfeed.friend.entity.Friend;
 import com.cordingrecipe.groupnewsfeed.friend.repository.FriendRepository;
 import com.cordingrecipe.groupnewsfeed.user.entity.User;
@@ -16,8 +17,9 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
-import static com.cordingrecipe.groupnewsfeed.friend.entity.Friend.FriendRequestStatus.*;
+import static com.cordingrecipe.groupnewsfeed.friend.entity.Friend.FriendRequestStatus.ACCEPTED;
 
 @Service
 @RequiredArgsConstructor
@@ -35,8 +37,8 @@ public class FriendService {
         User loginUser = userRepository.findByIdOrElseThrow(userId);
 
         //수신유저 존재하지 않음
-        Long receiverId = createFriendRequestDto.getReceiverId();
-        User toUser = userRepository.findByIdOrElseThrow(receiverId);
+        Long toUserId = createFriendRequestDto.getToUserId();
+        User toUser = userRepository.findByIdOrElseThrow(toUserId);
 
         //자기 자신에게 친구요청
         if (loginUser.getId().equals(toUser.getId())) {
@@ -59,14 +61,15 @@ public class FriendService {
 
     //친구 요청 수락
     @Transactional
-    public FriendResponseDto acceptFriendRequest(Long userId, Long requesterId) {
+    public FriendResponseDto acceptFriendRequest(Long toUserId,Long fromUserId) {
 
         Friend friendRequest = friendRepository.findByFromUserIdAndToUserIdAndStatus(
-                requesterId, userId, Friend.FriendRequestStatus.PENDING).orElseThrow(() ->
+                fromUserId, toUserId, Friend.FriendRequestStatus.PENDING).orElseThrow(() ->
                 new CustomException(ErrorCode.FRIEND_REQUEST_NOT_FOUND));
 
+
         //요청 수락 권한 없음
-        friendRequest.ensureReceiverIs(userId);
+        friendRequest.ensureReceiverIs(toUserId);
 
         //이미 친구 상태의 경우
         if (friendRequest.getStatus() == ACCEPTED) {
@@ -81,9 +84,8 @@ public class FriendService {
         friendRepository.findByFromUserIdAndToUserId(friendRequest.getToUser().getId(), friendRequest.getFromUser().getId())
                 .ifPresent(Friend::acceptIfPending);
 
-
-        User fromUser = userRepository.findByIdOrElseThrow(userId);
-        User toUser = userRepository.findByIdOrElseThrow(requesterId);
+        User fromUser = userRepository.findByIdOrElseThrow(toUserId);
+        User toUser = userRepository.findByIdOrElseThrow(fromUserId);
 
         Friend friend = new Friend(fromUser, toUser);
         friend.accepted();
@@ -94,56 +96,59 @@ public class FriendService {
 
     //친구 요청 거절
     @Transactional
-    public FriendResponseDto rejectFriendRequest(Long userId, Long requesterId) {
+    public FriendResponseDto rejectFriendRequest(Long toUserId, Long fromUserId) {
 
-        //친구 요청이 존재하지 않습니다.
+        // 친구 요청 찾기 (from → to 방향)
         Friend friendRequest = friendRepository.findByFromUserIdAndToUserIdAndStatus(
-                requesterId, userId, Friend.FriendRequestStatus.PENDING).orElseThrow(() ->
-                new CustomException(ErrorCode.FRIEND_REQUEST_NOT_FOUND));
+                fromUserId, toUserId, Friend.FriendRequestStatus.PENDING
+        ).orElseThrow(() ->
+                new CustomException(ErrorCode.FRIEND_REQUEST_NOT_FOUND)
+        );
 
-        //요청 수락 권한 없음
+        // 권한 확인
+        friendRequest.ensureReceiverIs(toUserId);
 
-        friendRequest.ensureReceiverIs(userId);
-        //이미 친구상태면 요청 또 보낼 수 없음 (양방향)
-        if(friendRepository.isFriendInStatus(userId, requesterId,ACCEPTED)) {
+        // 이미 친구 상태면 거절 불가
+        if (friendRepository.isFriendInStatus(fromUserId, toUserId, ACCEPTED)) {
             throw new CustomException(ErrorCode.FRIEND_ALREADY_ACCEPTED);
         }
 
-        friendRequest.rejectRequest(); //set대신 status == 거절처리
-
-        User fromUser = userRepository.findByIdOrElseThrow(userId);
-        User toUser = userRepository.findByIdOrElseThrow(requesterId);
-
-
-        Friend friend = new Friend(fromUser,toUser);
-        friend.rejected();
-        friendRepository.save(friend);
-
-
-        friendRequest.rejected();
+        // 상태만 REJECTED로 변경
+        friendRequest.rejectRequest(); // 내부에서 this.status = REJECTED
         friendRepository.save(friendRequest);
 
         return new FriendResponseDto(friendRequest);
-
     }
 
-    //내 친구 목록 조회
     @Transactional
-    public List<FriendResponseDto> getReceivedRequests(Long userId) {
+    public List<FriendViewDto> getReceivedRequests(Long userId) {
+        //양방향으로 저장된 친구 목록 전부 가져옴
+        List<Friend> allFriends = new ArrayList<>();
+        allFriends.addAll(friendRepository.findByFromUserIdAndStatus(userId, ACCEPTED));
+        allFriends.addAll(friendRepository.findByToUserIdAndStatus(userId, ACCEPTED));
 
-        List<Friend> fromAccepted = friendRepository
-                .findByFromUserIdAndStatus(userId, ACCEPTED);
-        List<Friend> toAccepted = friendRepository
-                .findByToUserIdAndStatus(userId, ACCEPTED);
+        //중복 제거 항상 fromId < toId 인 경우
+        return allFriends.stream()
+                .filter(friend -> {
+                    Long fromId = friend.getFromUser().getId();
+                    Long toId = friend.getToUser().getId();
 
-        List<Friend> all = new ArrayList<>();
-        all.addAll(fromAccepted);
-        all.addAll(toAccepted);
+                    return fromId < toId;
+                })
+                .map(friend -> {
+                    // 나와 연결된 상대방 친구만 추출
+                    Long fromId = friend.getFromUser().getId();
 
-        return all.stream()
-                .map(FriendResponseDto::new)
+                    // 내가 from이면 → to가 친구 / 내가 to면 → from이 친구
+                    User other = fromId.equals(userId)
+                            ? friend.getToUser()
+                            : friend.getFromUser();
+
+                    return new FriendViewDto(other.getId(), other.getUsername());
+                })
                 .toList();
     }
+
 
     //나한테 친구 신청한 목록 조회
     public List<FriendResponseDto> getPendingFriendRequests(Long userId) {
@@ -157,35 +162,36 @@ public class FriendService {
     }
 
     //친구 단일 조회
-    public FriendResponseDto findFriends(Long fromUserId, Long toUserId, Long userId) {
+    public FriendViewDto findFriend(Long myId, Long targetUserId) {
+        Optional<Friend> optionalFriend = friendRepository
+                .findByFromUserIdAndToUserIdAndStatus(myId, targetUserId, ACCEPTED);
 
-        if (!userId.equals(fromUserId) && !userId.equals(toUserId)) {
-            throw new CustomException(ErrorCode.FRIEND_ACCESS_DENIED);
+        if (optionalFriend.isEmpty()) {
+            friendRepository.findByFromUserIdAndToUserIdAndStatus(targetUserId, myId, ACCEPTED);
         }
 
-        Friend friend = friendRepository
-                .findByFromUserIdAndToUserIdAndStatus(fromUserId, toUserId, ACCEPTED)
-                .orElseThrow(() -> new CustomException(ErrorCode.FRIEND_REQUEST_NOT_FOUND));
+        Friend friend = optionalFriend.orElseThrow(() ->
+                new CustomException(ErrorCode.FRIEND_REQUEST_NOT_FOUND)
+        );
 
-        return new FriendResponseDto(friend);
+        return new FriendViewDto(friend.getToUser().getId(), friend.getToUser().getUsername());
     }
 
 
     //친구 삭제
     @Transactional
-    public void deleteFriend(Long myId, Long userId) {
+    public void deleteFriend(Long myId, Long targetUserId) {
 
         Friend friend = friendRepository
-                .findByFromUserIdAndToUserId(myId, userId)
+                .findByFromUserIdAndToUserId(myId,targetUserId)
                 .orElseThrow(() -> new CustomException(ErrorCode.FRIEND_REQUEST_NOT_FOUND));
 
-        if(!userId.equals(friend.getToUser().getId())&& !userId.equals(friend.getFromUser().getId())) {
+        if(!targetUserId.equals(friend.getToUser().getId())&& !targetUserId.equals(friend.getFromUser().getId())) {
             throw new CustomException(ErrorCode.FRIEND_DELETE_FORBIDDEN);
         }
 
         friendRepository.delete(friend);
 
-        //반대방향 처리 값이 존재해야 delete있으면(friend 객체가 존재하면) → delete()로 삭제해라"
         friendRepository.findByFromUserIdAndToUserId(
                 friend.getToUser().getId(),
                 friend.getFromUser().getId()
@@ -195,9 +201,3 @@ public class FriendService {
 }
 
 
-//friend클래스 이름 변경
-//행위 메서드 생성
-//acceptIfPending()으로 메서드 이름 변경.
-//이미 친구상태면 요청 또 보낼 수 없음 (양방향) 메서드 repository책임지도록 리펙토링.
-//validate클래스 삭제 후 검증 책임이 Friend 도메인 객체로. Repository 인터페이스에 boolean로직 정의
-//friend테이블 외래키 이름 변경

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,8 @@
 spring.application.name=group-newsfeed
 spring.datasource.url=jdbc:mysql://localhost:3306/newsfeed
 
-spring.datasource.username=${DB_NAME}
-spring.datasource.password=${DB_PASSWORD}
+spring.datasource.username=root
+spring.datasource.password=esca5323
 
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,8 @@
 spring.application.name=group-newsfeed
 spring.datasource.url=jdbc:mysql://localhost:3306/newsfeed
 
-spring.datasource.username=root
-spring.datasource.password=esca5323
+spring.datasource.username=${DB_NAME}
+spring.datasource.password=${DB_PASSWORD}
 
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 


### PR DESCRIPTION
친구 목록 조회 시 로그인한 사용자를 기준으로 상대방의 정보만 반환하도록 구조를 변경하고 중복 데이터는 제거하였습니다. (db에는 양방향으로 적용됨.)
기존의 fromUser, toUser 필드는 응답용으로는 적합하지 않아 friendId와 friendName만 포함된 전용 DTO를 새로 만들어 사용자 입장에서 직관적으로 조회되도록 개선하였습니다.