### PR TITLE
fix:댓글 수정 권한 수정

### DIFF
--- a/src/main/java/com/cordingrecipe/groupnewsfeed/comment/entity/Comment.java
+++ b/src/main/java/com/cordingrecipe/groupnewsfeed/comment/entity/Comment.java
@@ -49,8 +49,8 @@ public class Comment extends BaseEntity {
     }
 
     // 로그인된 유저와 댓글 작성자가 같은지 확인하는 메서드
-    public boolean hasDeleteRole(Long commentId, Long userId){
-        if(commentId.equals(userId)){
+    public boolean hasDeleteRole(Comment comment, Long userId){
+        if(comment.getUser().getId().equals(userId)){
             return true;
         } else{
             return false;

--- a/src/main/java/com/cordingrecipe/groupnewsfeed/comment/service/CommentService.java
+++ b/src/main/java/com/cordingrecipe/groupnewsfeed/comment/service/CommentService.java
@@ -58,7 +58,7 @@ public class CommentService {
         post.isMatched(post,comment);
 
         // 댓글 작성자 본인이 아닐시 예외 발생
-        if(!(comment.hasDeleteRole(commentId, userId))){
+        if(!(comment.hasDeleteRole(comment, userId))){
             throw new CustomException(ErrorCode.COMMENT_ACCESS_DENIED);
         }
 
@@ -77,7 +77,7 @@ public class CommentService {
         post.isMatched(post,comment);
 
         boolean isPostWriter = user.hasDeleteRole(userId, post); // 게시글 작성자인지 확인
-        boolean isCommentWriter = comment.hasDeleteRole(commentId, userId); // 댓글 작성자인지 확인
+        boolean isCommentWriter = comment.hasDeleteRole(comment, userId); // 댓글 작성자인지 확인
 
         // 댓글 작성자 및 게시글 작성자 본인이 아닐시 예외 발생
         if(!(isPostWriter || isCommentWriter)){


### PR DESCRIPTION
- 댓글 수정시 작성자 본인만 수정할 수 있게 구현하였지만 의도와 다르게 작성자의 아이디가 아닌 댓글의 아이디로 비교가 되어 제대로 권한이 확인되지 않는 점을 수정하여 올바르게 작동하게함